### PR TITLE
Add CONTRIBUTING and exclude internal docs from published site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing to PushNav
+
+Thank you for your interest in PushNav!
+
+## Code contributions
+
+**PushNav is not accepting code contributions at this time.**
+
+The project is in early development and the maintainer is still settling the architecture, scope, and direction. Pull requests will be closed without review for now. This will change once the project stabilizes — watch the repo for an update.
+
+## Bug reports and issues
+
+**Bug reports, issues, and feedback are very welcome.** If you've found a bug, hit a crash, run into a setup problem, or have a suggestion, please [open an issue](https://github.com/meridianfield/pushnav/issues).
+
+When reporting a bug, it helps to include:
+
+- Your operating system and version (e.g. macOS 14.5, Ubuntu 24.04, Windows 11)
+- The PushNav version (or commit hash if running from source)
+- Your camera and lens (if relevant)
+- Steps to reproduce the issue
+- What you expected to happen, and what actually happened
+- Any relevant log output or screenshots
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ docs_dir: docs
 
 exclude_docs: |
   .DS_Store
+  superpowers/
 
 theme:
   name: material


### PR DESCRIPTION
Add CONTRIBUTING.md noting code contributions are not yet accepted while welcoming bug reports and issues. Exclude docs/superpowers/ (internal planning specs) from the MkDocs build so they aren't published on GitHub Pages.