### PR TITLE
docs(social): set og:image to the tracking screenshot

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -5,4 +5,17 @@
   {# GoatCounter analytics — privacy-friendly, no cookies, ~3 KB #}
   <script data-goatcounter="https://pushnav.goatcounter.com/count"
           async src="//gc.zgo.at/count.js"></script>
+
+  {# Social preview image. Without an explicit og:image, scrapers fall back
+     to the first image on the page (typically the Bortle 8.5 camera frame
+     in the Who-is section), which renders as a noisy gray rectangle in
+     Twitter/Slack/Discord thumbnails. Force them to use the app tracking
+     screenshot, which actually communicates what PushNav is. #}
+  <meta property="og:image" content="https://meridianfield.github.io/pushnav/assets/pushnav.0.2.0-tracking.png">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="2122">
+  <meta property="og:image:height" content="1640">
+  <meta property="og:image:alt" content="PushNav in tracking mode — live camera feed, push-direction guidance, and the 3D Sky View dome.">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://meridianfield.github.io/pushnav/assets/pushnav.0.2.0-tracking.png">
 {% endblock %}


### PR DESCRIPTION
Without an explicit og:image, GitHub / Twitter / Slack / Discord scrapers fall back to the first image on the page, which picks up the Bortle 8.5 camera frame from the "Who is PushNav for?" section and renders as a noisy gray rectangle in the link preview. Force the preview to use the desktop-app tracking screenshot, which actually communicates what PushNav is at thumbnail size.

  overrides/main.html
    - Adds og:image, og:image:type / width / height / alt, plus twitter:card=summary_large_image and twitter:image. The block lives inside the existing extrahead override alongside the GoatCounter snippet.
    - Image URL is absolute (https://meridianfield.github.io/pushnav/…), required by the OG spec for scrapers that arrive without a base URL.

Notes:
- One image for all pages — every page on the site shares the same social preview. Per-page override would need a frontmatter-driven Jinja read, deferred.
- Image aspect ratio is 2122×1640 (~1.29:1). Twitter's summary_large_image cropping favours ~1.91:1, so Twitter will trim top and bottom. Center frame (live view + Sky View dome + step bar) stays visible. Acceptable for now.
- After deploy, force a re-scrape via the platforms' card validators (Twitter, Facebook, LinkedIn) so cached previews refresh.