### PR TITLE
chore: gitignore .cache/ (tetra3rs Gaia DB and other runtime caches)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ nuitka-crash-report.xml
 node_modules/
 web/dist/
 web/.vite/
+
+# Runtime caches (e.g. tetra3rs Gaia DB)
+.cache/


### PR DESCRIPTION
Keeps the 52 MB tetra3rs_gaia.bin (and any future runtime cache files) out of git status noise.