### PR TITLE
docs: add Google Search Console verification file

### DIFF
--- a/docs/googlebdc4dfd7b82118ab.html
+++ b/docs/googlebdc4dfd7b82118ab.html
@@ -1,0 +1,1 @@
+google-site-verification: googlebdc4dfd7b82118ab.html


### PR DESCRIPTION
Drops the verification HTML into docs/ so MkDocs publishes it at https://meridianfield.github.io/pushnav/googlebdc4dfd7b82118ab.html for Search Console URL-prefix verification of the project site.