### PR TITLE
fix(ui): clarify Stellarium vs LX200 connectivity labels

### DIFF
--- a/web/src/components/settings/Connectivity.tsx
+++ b/web/src/components/settings/Connectivity.tsx
@@ -52,7 +52,7 @@ export function Connectivity({ state }: Props) {
         <Row
           label={
             <span>
-              Stellarium <ActivityDot active={state.stellarium.active} />
+              Stellarium (desktop) <ActivityDot active={state.stellarium.active} />
             </span>
           }
         >
@@ -61,7 +61,7 @@ export function Connectivity({ state }: Props) {
         <Row
           label={
             <span>
-              LX200 (SkySafari) <ActivityDot active={state.lx200.active} />
+              LX200 (SkySafari / Stellarium Mobile) <ActivityDot active={state.lx200.active} />
             </span>
           }
         >


### PR DESCRIPTION
## Problem

Issue #29: Stellarium Mobile PLUS won't connect from a phone, while SkySafari works fine on the same setup.

Root cause is a **UI labeling trap**, not a protocol defect. PushNav runs two servers with very different reach:

| Settings row (before) | Address | Bind | Intended client |
|---|---|---|---|
| **Stellarium** | `localhost:10001` | `127.0.0.1` (localhost-only) | Stellarium **desktop**, same machine |
| **LX200 (SkySafari)** | `<LAN-IP>:4030` | `0.0.0.0` (LAN) | SkySafari, **Stellarium Mobile**, INDI, ASCOM |

A user with **Stellarium Mobile** on their phone naturally reads the row labeled "Stellarium" and points the phone at `localhost:10001` — which can never work: it's localhost-only *and* the wrong protocol. The row that actually serves Stellarium Mobile is the one labeled "LX200 (SkySafari)", which gives no hint it's the right one for a *Stellarium* mobile user.

## Verification

- The native Stellarium binary-protocol server binds `127.0.0.1`; a connection to the machine's LAN IP (what a phone dials) is **refused** — confirmed with a live socket test.
- Stellarium Mobile PLUS supports only **NexStar/SynScan and LX200** (per [Stellarium Labs docs](https://stellarium-labs.com/telescope-control-in-stellarium-mobile-plus/)) — it does not speak the native desktop binary protocol at all. So the LX200 server on `:4030` is the correct and only path.
- Drove the real `Lx200Server` over a loopback socket simulating the Stellarium Mobile handshake (`:GVP#` → `LX200 Classic#`, `:GR#`/`:GD#`, goto sequence, unknown-command resilience) — all correct. LX200 unit/server tests pass (60).

## Change

UI-only relabel in `web/src/components/settings/Connectivity.tsx`:
- `Stellarium` → **`Stellarium (desktop)`**
- `LX200 (SkySafari)` → **`LX200 (SkySafari / Stellarium Mobile)`**

Verified the labels render correctly in the running app.

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)