### PR TITLE
fix(build-windows): derive numeric PE version tuple for Nuitka

### DIFF
--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -37,6 +37,12 @@ REM Read version from VERSION.json (single source of truth)
 for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "(Get-Content '%REPO_ROOT%\data\VERSION.json' | ConvertFrom-Json).app_version"`) do set "APP_VERSION=%%V"
 echo ==^> Version: %APP_VERSION%
 
+REM Windows PE resource versions (FILEVERSION/PRODUCTVERSION) must be a numeric
+REM 4-part tuple, so strip any SemVer pre-release suffix and pad to 4 integers
+REM (e.g. "0.2.1-beta" -> "0.2.1.0"). User-facing version strings keep the suffix.
+for /f "usebackq delims=" %%V in (`powershell -NoProfile -Command "$n=('%APP_VERSION%' -split '-')[0]; $p=@($n -split '\.'); while($p.Count -lt 4){$p+='0'}; ($p[0..3] -join '.')"`) do set "WIN_VERSION=%%V"
+echo ==^> Windows resource version: %WIN_VERSION%
+
 echo ==^> Cleaning previous build
 if exist "%BUILD_DIR%" rmdir /s /q "%BUILD_DIR%"
 mkdir "%BUILD_DIR%"
@@ -94,8 +100,8 @@ uv run python -m nuitka ^
     --windows-product-name=PushNav ^
     --windows-company-name="Arun Venkataswamy" ^
     --windows-file-description="PushNav - plate-solving push-to" ^
-    --windows-product-version=%APP_VERSION%.0 ^
-    --windows-file-version=%APP_VERSION%.0 ^
+    --windows-product-version=%WIN_VERSION% ^
+    --windows-file-version=%WIN_VERSION% ^
     --output-dir="%BUILD_DIR%" ^
     --output-filename=PushNav.exe ^
     --include-package=numpy ^


### PR DESCRIPTION
## Problem

The Windows CI build failed for the `v0.2.1-beta` tag:

```
--windows-file-version=0.2.1-beta.0
FATAL: Error, file version must be a tuple of up to 4 integer values.
ERROR: Nuitka dist not found
```

Nuitka's `--windows-product-version` / `--windows-file-version` map to the Windows PE `FILEVERSION`/`PRODUCTVERSION` resource, which must be a tuple of **up to 4 integers**. The script passed `%APP_VERSION%.0`, so a SemVer pre-release tag like `v0.2.1-beta` produced `0.2.1-beta.0` — not an integer tuple — and Nuitka aborted. macOS/Linux don't have this PE-resource constraint, which is why only Windows broke.

## Fix

`scripts/build_windows.bat`: compute a sanitized `WIN_VERSION` (strip the pre-release suffix, pad to four integers — e.g. `0.2.1-beta` → `0.2.1.0`) and use it **only** for the two Nuitka resource-version flags. The display banner, Inno Setup installer, and in-app `VERSION.json` keep the full `0.2.1-beta` string.

This is the right layer: keep the SemVer pre-release tag as-is (correct convention for a non-GA test build); the numeric tuple is purely a Windows packaging requirement.

## Verification

Validated the version-munging algorithm produces valid numeric tuples:

| input | output |
|---|---|
| `0.2.1-beta` | `0.2.1.0` |
| `0.2.1-rc.1` | `0.2.1.0` |
| `0.2.1-beta.2` | `0.2.1.0` |
| `0.2.1` | `0.2.1.0` |
| `1.0` | `1.0.0.0` |

Final confirmation requires a Windows runner — recommend a `workflow_dispatch` Windows build after merge, then re-cut the `v0.2.1-beta` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)