### PR TITLE
feat(lx200): answer ACK (0x06) so Stellarium Mobile PLUS auto-detects

### DIFF
--- a/python/evf/lx200/protocol.py
+++ b/python/evf/lx200/protocol.py
@@ -150,6 +150,17 @@ class Lx200Context:
 
 # -- dispatch ----------------------------------------------------------------
 
+# LX200 ACK handshake. A client sends a bare ACK byte (0x06, no '#' terminator)
+# to auto-detect the controller and expects the mount's alignment-mode char
+# back: 'A'=AltAz, 'L'=Land, 'P'=Polar. The value is cosmetic for detection —
+# any valid char confirms "this is an LX200". We answer 'P' (Polar) because
+# PushNav reports equatorial RA/Dec. Stellarium Mobile PLUS's protocol probe
+# relies on this; without it, LX200 auto-detection fails. The ACK is not
+# '#'-framed, so Lx200Server answers it directly (see _handle_client_data),
+# not through dispatch().
+ACK_BYTE = b"\x06"
+ALIGNMENT_MODE_REPLY = b"P"
+
 # SkySafari tolerates variable-length padding here; 29 bytes matches the
 # Meade reference implementation's canonical reply.
 _CM_REPLY = b"Coordinates matched.        #"

--- a/python/evf/lx200/server.py
+++ b/python/evf/lx200/server.py
@@ -32,7 +32,13 @@ import time
 
 from evf.engine.goto_target import GotoTarget
 from evf.engine.pointing import PointingState
-from evf.lx200.protocol import Lx200ClientState, Lx200Context, dispatch
+from evf.lx200.protocol import (
+    ACK_BYTE,
+    ALIGNMENT_MODE_REPLY,
+    Lx200ClientState,
+    Lx200Context,
+    dispatch,
+)
 from evf.paths import sounds_dir
 
 logger = logging.getLogger(__name__)
@@ -193,12 +199,31 @@ class Lx200Server:
             else:
                 state.recv_buffer = state.recv_buffer[last_colon:]
 
+        # Answer ACK (0x06) probes first. These are bare bytes with no '#'
+        # terminator, so the command loop below never sees them — a client doing
+        # protocol auto-detection (e.g. Stellarium Mobile PLUS) sends an ACK and
+        # waits for the alignment-mode char to confirm an LX200 is present. One
+        # reply per ACK byte, mirroring a real mount; ordering vs. command
+        # replies in the same recv() is immaterial (the ACK only appears during
+        # the connect/identify handshake, never interleaved with polling).
+        ack_count = state.recv_buffer.count(ACK_BYTE)
+        if ack_count:
+            state.recv_buffer = state.recv_buffer.replace(ACK_BYTE, b"")
+            self._last_activity_at = time.monotonic()
+            logger.debug("LX200 <- ACK x%d  -> %r", ack_count, ALIGNMENT_MODE_REPLY)
+            try:
+                client.sendall(ALIGNMENT_MODE_REPLY * ack_count)
+            except (ConnectionResetError, BrokenPipeError, OSError):
+                self._remove_client(client)
+                return
+
         # Process every '#'-terminated command in the buffer
         while b"#" in state.recv_buffer:
             cmd, _, rest = state.recv_buffer.partition(b"#")
             state.recv_buffer = rest
-            # Strip stray leading whitespace / control bytes (some clients send
-            # ACK 0x06 probes; Meade Generic sends :<cmd># cleanly)
+            # Strip stray leading whitespace / control bytes (ACK 0x06 is
+            # already handled above; keep it here defensively. Meade Generic
+            # sends :<cmd># cleanly).
             cmd = cmd.lstrip(b"\x00 \r\n\t\x06")
             if not cmd:
                 continue

--- a/specs/start/SPEC_PROTOCOL_LX200.md
+++ b/specs/start/SPEC_PROTOCOL_LX200.md
@@ -44,6 +44,7 @@ LX200 is ASCII. Commands from the client are framed as `:<cmd>#` (leading colon,
 - **Fixed-width ASCII** terminated by `#` for getters (`:GR#`, `:GD#`, `:GVP#`, …)
 - **A single ASCII digit with no terminator** for target-set acknowledgments (`:Sr`, `:Sd`) — `1` = accepted, `0` = parse failed.
 - For `:MS#`, **either** a single `0` (slew started — both pending RA and Dec were set) **or** a `#`-terminated objection string of the form `1<msg>#` (the only objection PushNav currently emits is `1<no target set>#` when one or both pending values are missing).
+- **A single ASCII char with no terminator** for the `ACK` (`0x06`) alignment-mode query — see §3.4. This is *not* `:`-framed; it is a bare byte.
 - **Nothing at all** for fire-and-forget commands (`:Q#`, `:U#`, unknown commands)
 
 There is no length prefix, no checksum, no keep-alive. The socket stays open; the client polls `:GR#`/`:GD#` at 1–5 Hz.
@@ -113,6 +114,30 @@ After SkySafari sends `:MS#` it polls `:D#` ~1 Hz and transitions its button fro
 - everything else not listed in §3.1 or §3.2
 
 Unknown commands log at DEBUG only; no log spam above that level.
+
+### 3.4 `ACK` (`0x06`) — alignment-mode query / protocol auto-detect
+
+| Sent by client | Response |
+|----------------|----------|
+| `0x06` (bare ACK byte, no `:` prefix, no `#` terminator) | single char `P` (no terminator) |
+
+A real Meade mount answers the `ACK` byte with its alignment mode — `A` (AltAz),
+`L` (Land), or `P` (Polar). Clients that **auto-detect** the controller (rather
+than connect via a saved scope-type preset) use this as the LX200 "are you
+there?" probe: they send `0x06` and treat any of `A`/`L`/`P` as confirmation.
+
+PushNav answers **`P`** (Polar) because it reports equatorial RA/Dec; the value
+is cosmetic — any valid char confirms LX200. The byte is **not** `#`-framed, so
+`Lx200Server` answers it directly in its receive loop (one reply per ACK byte),
+not through `dispatch()`. One ACK per `0x06` mirrors a real mount.
+
+**Why this matters.** **Stellarium Mobile PLUS** identifies the controller by
+probing NexStar first (echo command `K<x>`, which we ignore → it times out and
+moves on — we intentionally do *not* emulate NexStar) and then LX200 via this
+`ACK`. Without an answer to the `ACK`, Stellarium reports *"Cannot identify a
+telescope protocol"* and never connects, even though `:GR#`/`:GD#` would work.
+SkySafari connects via an explicit "Meade LX-200" preset and does not rely on
+this probe, which is why it worked before this was implemented.
 
 ---
 
@@ -468,7 +493,10 @@ server level (§6.2.1) precisely because of this.
 ### 8.2 Stellarium Mobile PLUS
 - Menu → Observing Tools → Telescope → Add
 - Connection: **Network (TCP)**; IP = PushNav host; Port = **4030**
-- Protocol: leave on auto-detect; answering `:GVP#` with `LX200 Classic` is enough.
+- Protocol: leave on **auto-detect**. Stellarium probes NexStar first (we ignore
+  it → times out) then LX200 via the `ACK` (`0x06`) handshake (§3.4), which we
+  answer with the alignment-mode char. That `ACK` reply is what makes
+  auto-detect succeed; the `:GVP#` → `LX200 Classic` identity is read afterwards.
 
 ### 8.3 INDI (KStars)
 On the desktop:

--- a/tests/test_lx200_server.py
+++ b/tests/test_lx200_server.py
@@ -107,6 +107,67 @@ class TestGetters:
         s.close()
 
 
+def _recv_exact(sock: socket.socket, n: int) -> bytes:
+    """Read exactly n bytes (or whatever arrives within the timeout)."""
+    buf = b""
+    start = time.time()
+    while time.time() - start < 2.0 and len(buf) < n:
+        try:
+            chunk = sock.recv(n - len(buf))
+        except socket.timeout:
+            break
+        if not chunk:
+            break
+        buf += chunk
+    return buf
+
+
+class TestAckHandshake:
+    """LX200 ACK (0x06) auto-detection handshake used by Stellarium Mobile PLUS."""
+
+    def test_bare_ack_returns_alignment_char(self, server):
+        srv, _, _ = server
+        s = _connect(srv)
+        s.sendall(b"\x06")
+        assert _recv_exact(s, 1) == b"P"
+        s.close()
+
+    def test_stellarium_probe_hash_then_ack(self, server):
+        # Stellarium's observed LX200 probe: a '#' flush followed by the ACK.
+        # The '#' yields no command; the ACK must still be answered.
+        srv, _, _ = server
+        s = _connect(srv)
+        s.sendall(b"#\x06")
+        assert _recv_exact(s, 1) == b"P"
+        s.close()
+
+    def test_ack_then_command_in_same_recv(self, server):
+        # ACK answered first, then the '#'-framed command still dispatches.
+        srv, _, _ = server
+        s = _connect(srv)
+        s.sendall(b"\x06:GVP#")
+        assert _recv_exact(s, len(b"PLX200 Classic#")) == b"PLX200 Classic#"
+        s.close()
+
+    def test_multiple_acks_each_answered(self, server):
+        srv, _, _ = server
+        s = _connect(srv)
+        s.sendall(b"\x06\x06")
+        assert _recv_exact(s, 2) == b"PP"
+        s.close()
+
+    def test_polling_works_after_ack(self, server):
+        # Regression: detection handshake must not disturb normal polling.
+        srv, ps, _ = server
+        ps.update(ra_j2000=90.0, dec_j2000=45.0, roll=0.0, matches=10, prob=0.01)
+        s = _connect(srv)
+        s.sendall(b"\x06")
+        assert _recv_exact(s, 1) == b"P"
+        s.sendall(b":GVP#")
+        assert _recv_until_hash(s) == b"LX200 Classic#"
+        s.close()
+
+
 class TestMultiClientIsolation:
     def test_precision_per_client(self, server):
         srv, ps, _ = server


### PR DESCRIPTION
## Problem (issue #29)

Stellarium Mobile PLUS auto-detects a networked telescope by probing protocols over the TCP link. From a user's phone log connecting to our LX200 server (`192.168.0.115:4030`):

```
Trying NexStar...
Ka => TRX timeout
Echo not working, no NexStar-compatible controller connected
Trying LX200...
## =>
#[6] =>
Cannot identify a telescope protocol on serial connection
```

It probes **NexStar** (echo command `K<x>`) then **LX200** via a bare **ACK byte `0x06`**, expecting the mount's alignment-mode char back. Our server stripped `0x06` as a control byte and only processed `#`-terminated commands, so the ACK went unanswered → *"Cannot identify a telescope protocol"*, even though `:GR#`/`:GD#` polling would have worked. SkySafari was unaffected because it connects via an explicit "Meade LX-200" preset, not auto-detect.

## Change

Answer the ACK directly in the server receive loop (it is **not** `#`-framed) with **`P`** (Polar — PushNav reports equatorial RA/Dec; the value is cosmetic, any of `A`/`L`/`P` confirms LX200). One reply per ACK byte, mirroring a real mount.

We intentionally **do not emulate NexStar** — letting that probe time out and falling through to LX200 is correct.

- `lx200/protocol.py` — `ACK_BYTE` + `ALIGNMENT_MODE_REPLY` constants.
- `lx200/server.py` — reactive ACK reply in `_handle_client_data`, before the command loop.
- `SPEC_PROTOCOL_LX200.md` — §2 wire format, new §3.4 (ACK handshake), §8.2 (Stellarium setup).

## Verification

- **Confirmed working on a real Stellarium Mobile PLUS device** (reporter's setup) — it now identifies LX200 and connects.
- Live loopback replaying the phone's exact sequence: NexStar `Ka` → timeout (correct), `#` → no reply (correct), **ACK → `P`** (detected), `:GR#` → valid coords.
- **No regression:**
  - Binary Stellarium server (port 10001) shares no code with `lx200/` and has no `0x06` semantics — 13/13 Stellarium tests pass.
  - The ACK reply is **purely reactive** (emitted only on receiving `0x06`), so SkySafari/INDI/ASCOM — which don't auto-detect — see a byte-for-byte identical stream. 0 of the pre-existing LX200 tests send `0x06`; all pass.
  - `0x06` (ACK) ≠ `'6'` (ASCII `0x36`), so coordinate commands never false-trigger.
- 5 new server tests (bare ACK, `#`+ACK probe, ACK-then-command, multiple ACKs, polling-after-ACK). Full suite: **274 passed**.

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)