### PR TITLE
fix(lx200): add J2000 epoch option for Stellarium Mobile PLUS

### DIFF
--- a/python/evf/config/manager.py
+++ b/python/evf/config/manager.py
@@ -34,6 +34,7 @@ DEFAULT_CONFIG = {
     "calibration": {"finder_rotation": 0.0, "sync_d_body": None},
     "logging": {"verbose": False},
     "audio": {"enabled": True},
+    "lx200": {"epoch": "jnow"},
     "webserver": {"port": 8765},
     "location": {"latitude": None, "longitude": None},
 }
@@ -200,6 +201,15 @@ class ConfigManager:
     @verbose.setter
     def verbose(self, value: bool) -> None:
         self.set("logging", "verbose", value)
+
+    @property
+    def lx200_epoch(self) -> str:
+        """Coordinate epoch reported on the LX200 server: 'jnow' or 'j2000'."""
+        return self.get("lx200", "epoch")
+
+    @lx200_epoch.setter
+    def lx200_epoch(self, value: str) -> None:
+        self.set("lx200", "epoch", value)
 
     @property
     def web_port(self) -> int:

--- a/python/evf/engine/engine.py
+++ b/python/evf/engine/engine.py
@@ -189,6 +189,20 @@ class Engine:
     def set_audio_enabled(self, enabled: bool) -> None:
         self.audio_enabled = enabled
 
+    def set_lx200_epoch(self, epoch: str) -> None:
+        """Set the LX200 reported coordinate epoch ('jnow' or 'j2000').
+
+        'jnow' is the LX200 standard (SkySafari / INDI / ASCOM / real Meade);
+        'j2000' is for Stellarium Mobile PLUS, which reads LX200 coords as J2000.
+        Persists to config and applies to the running server immediately.
+        """
+        epoch = epoch.lower()
+        if epoch not in ("jnow", "j2000"):
+            raise ValueError(f"lx200_epoch must be 'jnow' or 'j2000', got {epoch!r}")
+        self._config.lx200_epoch = epoch
+        if self._lx200 is not None:
+            self._lx200.set_report_j2000(epoch == "j2000")
+
     @property
     def location(self) -> dict:
         """Resolve the active observer location.
@@ -393,13 +407,15 @@ class Engine:
         """Start LX200 TCP server.
 
         Binds 0.0.0.0:4030 so mobile apps (SkySafari, Stellarium Mobile) can
-        reach it on the LAN. Always-on; no config toggle in v1.
+        reach it on the LAN. Always-on. The reported coordinate epoch follows
+        the lx200.epoch config (JNow standard; J2000 for Stellarium Mobile PLUS).
         """
         try:
             self._lx200 = Lx200Server(
                 self._pointing_state,
                 goto_target=self._goto_target,
                 app_version=self._app_version,
+                report_j2000=(self._config.lx200_epoch == "j2000"),
             )
             self._lx200.start()
         except Exception as exc:
@@ -438,6 +454,7 @@ class Engine:
                     "lx200": {
                         "active": self.lx200_active,
                         "address": self.lx200_address,
+                        "epoch": self._config.lx200_epoch,
                     },
                     "webserver": {"url": self.web_url},
                     "audio_enabled": self.audio_enabled,

--- a/python/evf/lx200/protocol.py
+++ b/python/evf/lx200/protocol.py
@@ -146,6 +146,12 @@ class Lx200Context:
     app_version: str
     pending_ra_jnow_hours: float | None = None
     pending_dec_jnow_deg: float | None = None
+    # Epoch reported on :GR#/:GD# and assumed for :Sr#/:Sd# input. Default JNow
+    # (LX200 standard — SkySafari / INDI / ASCOM / real Meade). When True, report
+    # and accept J2000 instead: Stellarium Mobile PLUS reads LX200 coords as J2000
+    # and has no epoch toggle, so without this its marker sits ~20' (one
+    # precession) off target. Settable at runtime via Lx200Server.set_report_j2000.
+    report_j2000: bool = False
 
 
 # -- dispatch ----------------------------------------------------------------
@@ -241,8 +247,11 @@ def _reply_get_ra(state: Lx200ClientState, ctx: Lx200Context) -> bytes:
     snap = ctx.pointing.read()
     if not snap.valid:
         return b"00:00:00#" if state.precision_hi else b"00:00.0#"
-    ra_jnow_deg, _ = j2000_to_jnow(snap.ra_j2000, snap.dec_j2000)
-    ra_hours = ra_jnow_deg / 15.0
+    if ctx.report_j2000:
+        ra_deg = snap.ra_j2000
+    else:
+        ra_deg, _ = j2000_to_jnow(snap.ra_j2000, snap.dec_j2000)
+    ra_hours = ra_deg / 15.0
     return format_ra_hi(ra_hours) if state.precision_hi else format_ra_lo(ra_hours)
 
 
@@ -250,8 +259,11 @@ def _reply_get_dec(state: Lx200ClientState, ctx: Lx200Context) -> bytes:
     snap = ctx.pointing.read()
     if not snap.valid:
         return b"+00*00:00#" if state.precision_hi else b"+00*00#"
-    _, dec_jnow_deg = j2000_to_jnow(snap.ra_j2000, snap.dec_j2000)
-    return format_dec_hi(dec_jnow_deg) if state.precision_hi else format_dec_lo(dec_jnow_deg)
+    if ctx.report_j2000:
+        dec_deg = snap.dec_j2000
+    else:
+        _, dec_deg = j2000_to_jnow(snap.ra_j2000, snap.dec_j2000)
+    return format_dec_hi(dec_deg) if state.precision_hi else format_dec_lo(dec_deg)
 
 
 def _handle_set_ra(arg: str, ctx: Lx200Context) -> bytes:
@@ -277,14 +289,21 @@ def _handle_set_dec(arg: str, ctx: Lx200Context) -> bytes:
 def _handle_move_slew(ctx: Lx200Context) -> bytes:
     if ctx.pending_ra_jnow_hours is None or ctx.pending_dec_jnow_deg is None:
         return b"1<no target set>#"
-    ra_jnow_deg = ctx.pending_ra_jnow_hours * 15.0
-    ra_j2000, dec_j2000 = jnow_to_j2000(ra_jnow_deg, ctx.pending_dec_jnow_deg)
+    ra_deg = ctx.pending_ra_jnow_hours * 15.0
+    dec_deg = ctx.pending_dec_jnow_deg
+    if ctx.report_j2000:
+        # Client speaks J2000 (e.g. Stellarium Mobile PLUS) — the target is
+        # already J2000, so store it verbatim with no precession.
+        ra_j2000, dec_j2000 = ra_deg, dec_deg
+    else:
+        ra_j2000, dec_j2000 = jnow_to_j2000(ra_deg, dec_deg)
     # GotoTarget.set() plays the ack sound internally — we do not call play_ack
     # separately to avoid a double-play. ctx.play_ack exists for future hooks.
     if ctx.goto_target is not None:
         ctx.goto_target.set(ra_j2000, dec_j2000)
     logger.info(
-        "LX200 GOTO: (JNow) RA=%.4fh Dec=%.4f° -> (J2000) RA=%.4f° Dec=%.4f°",
+        "LX200 GOTO: (%s) RA=%.4fh Dec=%.4f° -> (J2000) RA=%.4f° Dec=%.4f°",
+        "J2000" if ctx.report_j2000 else "JNow",
         ctx.pending_ra_jnow_hours,
         ctx.pending_dec_jnow_deg,
         ra_j2000,

--- a/python/evf/lx200/server.py
+++ b/python/evf/lx200/server.py
@@ -88,6 +88,7 @@ class Lx200Server:
         port: int = _DEFAULT_PORT,
         goto_target: GotoTarget | None = None,
         app_version: str = "0.0.0",
+        report_j2000: bool = False,
     ) -> None:
         self._host = host
         self._port = port
@@ -96,6 +97,7 @@ class Lx200Server:
             goto_target=goto_target,
             play_ack=_play_ack,
             app_version=app_version,
+            report_j2000=report_j2000,
         )
         self._clients: dict[socket.socket, Lx200ClientState] = {}
         # Monotonic timestamp of the most recent connect OR received command.
@@ -140,6 +142,15 @@ class Lx200Server:
         the LX200 indicator whenever `time.monotonic() - this < hold_seconds`.
         """
         return self._last_activity_at
+
+    def set_report_j2000(self, value: bool) -> None:
+        """Switch the reported coordinate epoch at runtime (JNow <-> J2000).
+
+        Shared across all current and future client connections. Used by the
+        engine when the user flips the LX200 epoch setting.
+        """
+        self._ctx.report_j2000 = bool(value)
+        logger.info("LX200 epoch set to %s", "J2000" if value else "JNow")
 
     # -- internal -------------------------------------------------------------
 

--- a/python/evf/webserver/server.py
+++ b/python/evf/webserver/server.py
@@ -487,6 +487,13 @@ class WebServer:
                 )
             if resp.status >= 400:
                 return resp
+        if "lx200_epoch" in body:
+            resp = await self._handle_api(
+                request,
+                lambda: self._actions.set_lx200_epoch(str(body["lx200_epoch"])),
+            )
+            if resp.status >= 400:
+                return resp
         return web.Response(status=204)
 
     async def _api_dev_inject_sample(self, request):

--- a/tests/test_lx200_server.py
+++ b/tests/test_lx200_server.py
@@ -208,6 +208,89 @@ class TestGoto:
         s.close()
 
 
+@pytest.fixture
+def j2000_server():
+    """LX200 server configured to report J2000 (Stellarium Mobile PLUS mode)."""
+    ps = PointingState()
+    gt = GotoTarget()
+    srv = Lx200Server(
+        ps, host="127.0.0.1", port=0, goto_target=gt, app_version="test",
+        report_j2000=True,
+    )
+    srv.start()
+    yield srv, ps, gt
+    srv.stop(timeout=2.0)
+
+
+class TestLx200Epoch:
+    """LX200 reports JNow by default (SkySafari / INDI / ASCOM / real Meade), but
+    Stellarium Mobile PLUS reads :GR/:GD as J2000 and offers no epoch toggle — so
+    its marker lands ~20' off (one precession). A user-selectable J2000 mode serves
+    J2000 to fix PLUS without disturbing the standard clients.
+    """
+
+    # Alnitak (J2000); precession to JNow shifts RA ~20' — far above the
+    # 1-second (15") high-precision rounding, so the two epochs are unambiguous.
+    _RA_J2000, _DEC_J2000 = 85.1897, -1.9426
+
+    def test_default_reports_jnow(self, server):
+        from evf.engine.epoch import j2000_to_jnow
+        from evf.lx200.protocol import format_ra_hi
+
+        srv, ps, _ = server
+        ps.update(ra_j2000=self._RA_J2000, dec_j2000=self._DEC_J2000,
+                  roll=0.0, matches=10, prob=0.01)
+        ra_jnow_deg, _ = j2000_to_jnow(self._RA_J2000, self._DEC_J2000)
+        s = _connect(srv)
+        s.sendall(b":GR#")
+        assert _recv_until_hash(s) == format_ra_hi(ra_jnow_deg / 15.0)
+        s.close()
+
+    def test_j2000_mode_reports_j2000(self, j2000_server):
+        from evf.engine.epoch import j2000_to_jnow
+        from evf.lx200.protocol import format_ra_hi
+
+        srv, ps, _ = j2000_server
+        ps.update(ra_j2000=self._RA_J2000, dec_j2000=self._DEC_J2000,
+                  roll=0.0, matches=10, prob=0.01)
+        ra_jnow_deg, _ = j2000_to_jnow(self._RA_J2000, self._DEC_J2000)
+        expected_j2000 = format_ra_hi(self._RA_J2000 / 15.0)
+        assert expected_j2000 != format_ra_hi(ra_jnow_deg / 15.0)  # precession visible
+        s = _connect(srv)
+        s.sendall(b":GR#")
+        assert _recv_until_hash(s) == expected_j2000
+        s.close()
+
+    def test_runtime_switch_to_j2000(self, server):
+        from evf.lx200.protocol import format_ra_hi
+
+        srv, ps, _ = server
+        ps.update(ra_j2000=self._RA_J2000, dec_j2000=self._DEC_J2000,
+                  roll=0.0, matches=10, prob=0.01)
+        srv.set_report_j2000(True)
+        s = _connect(srv)
+        s.sendall(b":GR#")
+        assert _recv_until_hash(s) == format_ra_hi(self._RA_J2000 / 15.0)
+        s.close()
+
+    def test_j2000_mode_reads_goto_target_as_j2000(self, j2000_server):
+        # In J2000 mode the :Sr/:Sd target is already J2000 — store it directly,
+        # do NOT precess JNow->J2000 (which would shift it ~20').
+        srv, _, gt = j2000_server
+        s = _connect(srv)
+        s.sendall(b":Sr 12:00:00#")
+        assert _recv_until_hash(s) == b"1"
+        s.sendall(b":Sd +00*00:00#")
+        assert _recv_until_hash(s) == b"1"
+        s.sendall(b":MS#")
+        assert _recv_until_hash(s) == b"0"
+        snap = gt.read()
+        assert snap.active is True
+        assert abs(snap.ra_j2000 - 180.0) < 0.001   # stored verbatim, not precessed
+        assert abs(snap.dec_j2000) < 0.001
+        s.close()
+
+
 class TestMalformedRecovery:
     def test_unknown_commands_do_not_break_stream(self, server):
         srv, _, _ = server

--- a/tests/test_webserver_api.py
+++ b/tests/test_webserver_api.py
@@ -102,6 +102,16 @@ async def test_settings_audio(server_and_actions):
 
 
 @pytest.mark.asyncio
+async def test_settings_lx200_epoch(server_and_actions):
+    ws, actions = server_and_actions
+    async with ClientSession() as s:
+        async with s.post(f"http://127.0.0.1:{ws._port}/api/settings",
+                          json={"lx200_epoch": "j2000"}) as resp:
+            assert resp.status == 204
+    actions.set_lx200_epoch.assert_called_once_with("j2000")
+
+
+@pytest.mark.asyncio
 async def test_actions_none_returns_503(tmp_path, monkeypatch):
     """When no actions are wired, POST /api/* returns 503 instead of 500."""
     monkeypatch.setenv("HOME", str(tmp_path))

--- a/web/src/components/settings/Connectivity.tsx
+++ b/web/src/components/settings/Connectivity.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import { QRCodeSVG } from "qrcode.react";
 import { ActivityDot } from "@/components/ActivityDot";
+import { api } from "@/lib/api";
 import type { EnginePayload } from "@/lib/types";
 
 interface Props {
@@ -67,6 +68,29 @@ export function Connectivity({ state }: Props) {
         >
           <code className="text-xs">{state.lx200.address ?? "off"}</code>
         </Row>
+        <div className="flex items-center justify-between pl-2">
+          <span className="text-xs text-muted-foreground">Coordinate epoch</span>
+          <div className="flex gap-1">
+            {(["jnow", "j2000"] as const).map((e) => (
+              <button
+                key={e}
+                type="button"
+                onClick={() => api.setSettings({ lx200_epoch: e })}
+                className={
+                  (state.lx200.epoch ?? "jnow") === e
+                    ? "rounded bg-primary px-2 py-0.5 text-xs text-primary-foreground"
+                    : "rounded px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground"
+                }
+              >
+                {e === "jnow" ? "JNow" : "J2000"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="pl-2 text-[10px] leading-tight text-muted-foreground">
+          JNow for SkySafari (standard). Switch to J2000 if Stellarium Mobile PLUS
+          centers slightly off target.
+        </div>
       </CardContent>
     </Card>
   );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -29,6 +29,7 @@ export const api = {
   setSettings: (s: {
     audio_enabled?: boolean;
     location?: { latitude: number; longitude: number } | null;
+    lx200_epoch?: "jnow" | "j2000";
   }) => post("/api/settings", s),
   setAdvanced: (s: { min_matches?: number; max_prob?: number }) =>
     post("/api/settings", s),

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -79,6 +79,8 @@ export interface ActivityLine {
   status?: unknown;
   object?: { name?: string; "localized-name"?: string } | null;
   location?: ObserverLocation | null;
+  /** LX200 only: reported coordinate epoch ("jnow" default, "j2000" for Stellarium Mobile PLUS). */
+  epoch?: "jnow" | "j2000";
 }
 
 export interface CameraBlock {


### PR DESCRIPTION
Stellarium Mobile PLUS reads LX200 :GR/:GD as J2000, not the LX200-standard JNow, so its marker sits ~20' (one precession) off target — verified with the scope on Alnitak showing as the Flame Nebula, while SkySafari on the same server is exact. The LX200 protocol doesn't encode an epoch, so this is a client convention mismatch, not a bug on our side.

Add a user-selectable LX200 coordinate epoch (config lx200.epoch, default jnow) with a JNow/J2000 toggle in Settings → Connectivity, right below the LX200 address. J2000 mode reports J2000 on :GR/:GD and accepts J2000 on :Sr/:Sd; applied to the running server at runtime. SkySafari / INDI / ASCOM / real Meade (all JNow) are unaffected.